### PR TITLE
4 APR 2020 - Version [a.2.1]:

### DIFF
--- a/va2/docs/Changes.txt
+++ b/va2/docs/Changes.txt
@@ -1,3 +1,12 @@
+4 APR 2020 - Version [a.2.1]:
+ [Change]
+  -Message verbosity settings persist between play sessions.
+  -Combat message priorities adjusted as follows:
+   >Initial attack and defend messages reduced to LOW from MAX.
+   >Successful evasion and deflection messages increased to HIGH from LOW.
+   >Hits resulting in damage increased to MAX from HIGH.
+   >Non-boss kill messages increased to MAX from HIGH(boss kill messages remain at MAX).
+
 4 APR 2020 - Version [a.2.0]:
  [Change]
   -Text screens no longer attempt to redraw themselves unless a meaningful change has taken place.

--- a/va2/src/combat/melee/MeleeResolver.java
+++ b/va2/src/combat/melee/MeleeResolver.java
@@ -12,7 +12,6 @@ import main.Session;
 import status.StatusType;
 import util.Grammar;
 import world.actor.Actor;
-import world.actor.ActorTemplate;
 import world.dungeon.Dungeon;
 import world.dungeon.floor.Floor;
 import world.dungeon.theme.ActorSet;
@@ -63,7 +62,8 @@ public class MeleeResolver extends CombatResolver {
                 attackerMeleeWeapon.resolveWeaponDamage(attackTactic == AttackTactic.BLOW);
         //counterattacks preserve any existing message - otherwise we need to reset it
         if (!(meleeAttackAction instanceof CounterAttackAction)){
-            message = (isAttackerPlayer || isDefenderPlayer)
+            message = ((isAttackerPlayer || isDefenderPlayer) &&
+                    Session.getMessageCenter().getPriorityThreshold() > PRIORITY_HIGH)
                     ? new Message(
                             MessageType.INFO,
                             Grammar.configure(
@@ -343,7 +343,7 @@ public class MeleeResolver extends CombatResolver {
                                         "your attack."
                                 ),
                                 isAttackerPlayer ? MessageType.WARNING : MessageType.INFO,
-                                PRIORITY_LOW
+                                PRIORITY_HIGH
                         );
                     }
                     return message;
@@ -373,7 +373,7 @@ public class MeleeResolver extends CombatResolver {
                                         "your attack."
                                 ),
                                 isAttackerPlayer ? MessageType.WARNING : MessageType.INFO,
-                                PRIORITY_LOW
+                                PRIORITY_HIGH
                         );
                     }
                     resolveContactInteraction(
@@ -451,7 +451,7 @@ public class MeleeResolver extends CombatResolver {
                             "damage."
                     ),
                     isAttackerPlayer ? MessageType.INFO : MessageType.ERROR,
-                    PRIORITY_HIGH
+                    PRIORITY_MAX
             );
         }
         //todo - if (damageToMind/Soul > 0 && isPlayer) updateMessage
@@ -483,7 +483,7 @@ public class MeleeResolver extends CombatResolver {
                     updateMessage(
                             "You have slain the " + defenderName + ".",
                             MessageType.INFO,
-                            PRIORITY_HIGH
+                            PRIORITY_MAX
                     );
                 d.addReward(defender.finalizeReward());
             }
@@ -535,7 +535,10 @@ public class MeleeResolver extends CombatResolver {
     }
     private static void updateMessage(String addition, MessageType type, int priority) {
         if (priority > Session.getMessageCenter().getPriorityThreshold()) return;
-        message.append(new Message(type, addition));
-        message.changeType(type);
+        if (message == null) message = new Message(type, addition);
+        else {
+            message.append(new Message(type, addition));
+            message.changeType(type);
+        }
     }
 }

--- a/va2/src/io/file/FileManager.java
+++ b/va2/src/io/file/FileManager.java
@@ -120,6 +120,7 @@ public class FileManager {
             Session.setEstateProgression((EstateProgression)ois.readObject());
             Session.setLanguageKnowledge((LanguageKnowledge)ois.readObject());
             Session.setLegacyResources((Inventory)ois.readObject());
+            Session.getMessageCenter().setPriorityThreshold((int)ois.readObject());
         } catch (EOFException eofe) {
             return false; //tried to load an empty profile - it was created but never written to
         } catch (Exception ex) {
@@ -164,6 +165,7 @@ public class FileManager {
             oos.writeObject(Session.getEstateProgression());
             oos.writeObject(Session.getLanguageKnowledge());
             oos.writeObject(Session.getLegacyResources());
+            oos.writeObject(Session.getMessageCenter().getPriorityThreshold());
         } catch (Exception e) {
             ErrorLogger.logFatalException(e);
         } finally {

--- a/va2/src/io/out/message/MessageCenter.java
+++ b/va2/src/io/out/message/MessageCenter.java
@@ -40,6 +40,10 @@ public class MessageCenter {
         newMessages = new ArrayList<>();
     }
 
+    public void setPriorityThreshold(int pt) {
+        priorityThreshold = pt;
+    }
+
     public int getPriorityThreshold() {
         return priorityThreshold;
     }


### PR DESCRIPTION
 [Change]
  -Message verbosity settings persist between play sessions.
  -Combat message priorities adjusted as follows:
   >Initial attack and defend messages reduced to LOW from MAX.
   >Successful evasion and deflection messages increased to HIGH from LOW.
   >Hits resulting in damage increased to MAX from HIGH.
   >Non-boss kill messages increased to MAX from HIGH(boss kill messages remain at MAX).